### PR TITLE
bob is going to need sudo access to run toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ listening on ens3, link-type EN10MB (Ethernet), capture size 65535 bytes
 Set a `/etc/passwd` entry for one of the users to `/usr/bin/toolbox`.
 
 ```
-useradd bob -m -p '*' -s /usr/bin/toolbox
+useradd bob -m -p '*' -s /usr/bin/toolbox -g sudo
 ```
 
 ```


### PR DESCRIPTION
the toolbox script needs sudo access, which was not granted in the
previous command

fixes coreos/toolbox#1
