### PR TITLE
Specifying a container on the public index fails due to / in container name

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -9,7 +9,7 @@ if [ -f "${toolboxrc}" ]; then
 	source "${toolboxrc}"
 fi
 
-machinename="${USER}-${TOOLBOX_DOCKER_IMAGE}"
+machinename=$(echo "${USER}-${TOOLBOX_DOCKER_IMAGE}" | sed -r 's/[^a-zA-Z0-9_.-]/_/g')
 machinepath="/var/lib/toolbox/${machinename}"
 
 if [ ! -d ${machinepath} ] || systemctl is-failed ${machinename} ; then
@@ -23,4 +23,4 @@ if [ ! -d ${machinepath} ] || systemctl is-failed ${machinename} ; then
 	sudo touch "${machinepath}"/etc/os-release
 fi
 
-sudo systemd-nspawn -D "${machinepath}" --share-system --bind=/:/media/root --bind=/usr:/media/root/usr --user=${TOOLBOX_USER}
+sudo systemd-nspawn -D "${machinepath}" --share-system --bind=/:/media/root --bind=/usr:/media/root/usr --user="${TOOLBOX_USER}"


### PR DESCRIPTION
```
core@core-01 ~ $ cat .toolboxrc 
TOOLBOX_DOCKER_IMAGE=coreos/apache
TOOLBOX_USER=root
core@core-01 ~ $ /usr/bin/toolbox
Pulling repository coreos/apache
87026dcb0044: Download complete 
511136ea3c5a: Download complete 
6170bb7b0ad1: Download complete 
9cd978db300e: Download complete 
2014/04/15 19:00:24 Error: Invalid container name (core-coreos/apache), only [a-zA-Z0-9_.-] are allowed
2014/04/15 19:00:24 Error: No such container: core-coreos/apache
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
Error: No such container: core-coreos/apache
2014/04/15 19:00:24 Error: failed to remove one or more containers
touch: cannot touch '/var/lib/toolbox/core-coreos/apache/etc/os-release': No such file or directory
Directory /var/lib/toolbox/core-coreos/apache lacks the binary to execute or doesn't look like a binary tree. Refusing.
```
