### PR TITLE
using tr to convert forward slashes to underscores

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -10,6 +10,9 @@ if [ -f "${toolboxrc}" ]; then
 fi
 
 machinename="${USER}-${TOOLBOX_DOCKER_IMAGE}"
+# Remove any slashes from the docker image path 
+machinename=$(echo $machinename | tr \/ _)
+
 machinepath="/var/lib/toolbox/${machinename}"
 
 if [ ! -d ${machinepath} ] || systemctl is-failed ${machinename} ; then


### PR DESCRIPTION
converting slashes in the docker image path to underscores. this
means that the form of the machine name may be parsed (sloppily) by
breaking on the first dash in the name

cc @jonboulle / @robszumski

```
[bharrington@leviathan-alticon-net bootengine]$ ssh bharrington@192.168.122.101
Warning: Permanently added '192.168.122.101' (RSA) to the list of known hosts.
Warning: Permanently added '192.168.122.101' (RSA) to the list of known hosts.
Last login: Wed Apr 16 17:57:23 2014 from 192.168.122.1
   ______                ____  _____
  / ____/___  ________  / __ \/ ___/
 / /   / __ \/ ___/ _ \/ / / /\__ \
/ /___/ /_/ / /  /  __/ /_/ /___/ /
\____/\____/_/   \___/\____//____/
Pulling repository coreos/apache
87026dcb0044: Download complete 
511136ea3c5a: Download complete 
6170bb7b0ad1: Download complete 
9cd978db300e: Download complete 
bharrington-coreos_apache
Spawning container bharrington-coreos_apache on /var/lib/toolbox/bharrington-coreos_apache. Press ^] three times within 1s to abort execution.
/etc/localtime is not a symlink, not updating container timezone.
root@localhost:~# 
root@localhost:~# cat /etc/os-release 
root@localhost:~# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=12.04
DISTRIB_CODENAME=precise
DISTRIB_DESCRIPTION="Ubuntu 12.04 LTS"
```
