### PR TITLE
feat(toolbox): pass through arguments

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -23,4 +23,4 @@ if [ ! -d ${machinepath} ] || systemctl is-failed ${machinename} ; then
 	sudo touch "${machinepath}"/etc/os-release
 fi
 
-sudo systemd-nspawn -D "${machinepath}" --share-system --bind=/:/media/root --bind=/usr:/media/root/usr --user="${TOOLBOX_USER}"
+sudo systemd-nspawn -D "${machinepath}" --share-system --bind=/:/media/root --bind=/usr:/media/root/usr --user="${TOOLBOX_USER}" "$@"


### PR DESCRIPTION
systemd-nspawn will happily take commands to execute. This is convenient
if we want to run something in the container but don't need an interactive shell.
This commit passes any toolbox parameters through to systemd-nspawn.

``` console
core@ip-172-31-14-253 ~ $ ./toolbox /bin/echo hello
unknown
Spawning container core-fedora on /var/lib/toolbox/core-fedora. Press ^] three times within 1s to abort execution.
/etc/localtime is not a symlink, not updating container timezone.
hello
```
