### PR TITLE
Toolbox wedged after failed download

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -12,8 +12,8 @@ fi
 
 machinename=$(echo "${USER}-${TOOLBOX_DOCKER_IMAGE}-${TOOLBOX_DOCKER_TAG}" | sed -r 's/[^a-zA-Z0-9_.-]/_/g')
 machinepath="/var/lib/toolbox/${machinename}"
-
-if [ ! -d ${machinepath} ] || systemctl is-failed ${machinename} ; then
+osrelease="${machinepath}/etc/os-release"
+if [ ! -f ${osrelease} ] || systemctl is-failed -q ${machinename} ; then
 	sudo mkdir -p "${machinepath}"
 	sudo chown ${USER}: "${machinepath}"
 
@@ -21,7 +21,7 @@ if [ ! -d ${machinepath} ] || systemctl is-failed ${machinename} ; then
 	docker run --name=${machinename} "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}" /bin/true
 	docker export ${machinename} | sudo tar -x -C "${machinepath}" -f -
 	docker rm ${machinename}
-	sudo touch "${machinepath}"/etc/os-release
+	sudo touch ${osrelease}
 fi
 
 sudo systemd-nspawn -D "${machinepath}" --share-system --bind=/:/media/root --bind=/usr:/media/root/usr --user="${TOOLBOX_USER}" "$@"


### PR DESCRIPTION
I ran `toolbox` on my machine before DNS had been configured.

```
$ toolbox
Pulling repository fedora
2014/08/18 21:18:52 Get https://index.docker.io/v1/repositories/fedora/images: dial tcp: lookup index.docker.io: connection refused
Unable to find image 'fedora:latest' locally
Pulling repository fedora
2014/08/18 21:18:52 Get https://index.docker.io/v1/repositories/fedora/images: dial tcp: lookup index.docker.io: connection refused
2014/08/18 21:18:52 Error: No such container: core-fedora-latest
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
Error response from daemon: No such container: core-fedora-latest
2014/08/18 21:18:52 Error: failed to remove one or more containers
touch: cannot touch '/var/lib/toolbox/core-fedora-latest/etc/os-release': No such file or directory
Directory /var/lib/toolbox/core-fedora-latest lacks the binary to execute or doesn't look like a binary tree. Refusing.
```

After this initial failure, toolbox was permanently stuck.

```
$ toolbox
unknown
Directory /var/lib/toolbox/core-fedora-latest lacks the binary to execute or doesn't look like a binary tree. Refusing.
```

Removing `/var/lib/toolbox/core-fedora-latest/` fixes the issue.
