### PR TITLE
Add SSH_AUTH_SOCK, and _only_ SSH_AUTH_SOCK, to the toolbox environment

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -24,4 +24,4 @@ if [ ! -f ${osrelease} ] || systemctl is-failed -q ${machinename} ; then
 	sudo touch ${osrelease}
 fi
 
-sudo systemd-nspawn --directory="${machinepath}" --capability=all --share-system --bind=/:/media/root --bind=/usr:/media/root/usr --user="${TOOLBOX_USER}" "$@"
+sudo ${SSH_AUTH_SOCK:+SSH_AUTH_SOCK=$SSH_AUTH_SOCK} systemd-nspawn --directory="${machinepath}" --capability=all --share-system --bind=/:/media/root --bind=/usr:/media/root/usr ${SSH_AUTH_SOCK:+--bind="$SSH_AUTH_SOCK":"$SSH_AUTH_SOCK"} ${SSH_AUTH_SOCK:+--setenv=SSH_AUTH_SOCK="$SSH_AUTH_SOCK"} --user="${TOOLBOX_USER}" "$@"


### PR DESCRIPTION
This allows ssh-agent forwarding to be exposed to the toolbox shell
