### PR TITLE
feat(toolbox): bind /run into toolbox container

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -24,4 +24,4 @@ if [ ! -f ${osrelease} ] || systemctl is-failed -q ${machinename} ; then
 	sudo touch ${osrelease}
 fi
 
-sudo systemd-nspawn --directory="${machinepath}" --capability=all --share-system --bind=/:/media/root --bind=/usr:/media/root/usr --user="${TOOLBOX_USER}" "$@"
+sudo systemd-nspawn --directory="${machinepath}" --capability=all --share-system --bind=/:/media/root --bind=/usr:/media/root/usr --bind=/run:/media/root/run --user="${TOOLBOX_USER}" "$@"


### PR DESCRIPTION
Having quick access to the hosts /run directory is helpful for
troubleshooting. Additionally this provides access to the docker socket
from within the toolbox.