### PR TITLE
Make toolbox data directory configurable

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -3,6 +3,7 @@
 TOOLBOX_DOCKER_IMAGE=fedora
 TOOLBOX_DOCKER_TAG=latest
 TOOLBOX_USER=root
+TOOLBOX_DIRECTORY="/var/lib/toolbox"
 
 toolboxrc="${HOME}"/.toolboxrc
 
@@ -11,7 +12,7 @@ if [ -f "${toolboxrc}" ]; then
 fi
 
 machinename=$(echo "${USER}-${TOOLBOX_DOCKER_IMAGE}-${TOOLBOX_DOCKER_TAG}" | sed -r 's/[^a-zA-Z0-9_.-]/_/g')
-machinepath="/var/lib/toolbox/${machinename}"
+machinepath="${TOOLBOX_DIRECTORY}/${machinename}"
 osrelease="${machinepath}/etc/os-release"
 if [ ! -f ${osrelease} ] || systemctl is-failed -q ${machinename} ; then
 	sudo mkdir -p "${machinepath}"


### PR DESCRIPTION
I am running CoreOS out of RAM, thus I need to tell toolbox where to store the images.