### PR TITLE
toolbox: split nspawn command to multiple lines

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -25,4 +25,11 @@ if [ ! -f ${osrelease} ] || systemctl is-failed -q ${machinename} ; then
 	sudo touch ${osrelease}
 fi
 
-sudo systemd-nspawn --directory="${machinepath}" --capability=all --share-system --bind=/:/media/root --bind=/usr:/media/root/usr --bind=/run:/media/root/run --user="${TOOLBOX_USER}" "$@"
+sudo systemd-nspawn \
+	--directory="${machinepath}" \
+	--capability=all \
+	--share-system \
+	--bind=/:/media/root \
+	--bind=/usr:/media/root/usr \
+	--bind=/run:/media/root/run \
+	--user="${TOOLBOX_USER}" "$@"


### PR DESCRIPTION
This makes it a bit easier to see what exactly is going on (and review
any changes in future)