### PR TITLE
Use dashes instead of underscores in machine name

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -14,7 +14,7 @@ if [ -f "${toolboxrc}" ]; then
 	source "${toolboxrc}"
 fi
 
-machinename=$(echo "${USER}-${TOOLBOX_DOCKER_IMAGE}-${TOOLBOX_DOCKER_TAG}" | sed -r 's/[^a-zA-Z0-9_.-]/_/g')
+machinename=$(echo "${USER}-${TOOLBOX_DOCKER_IMAGE}-${TOOLBOX_DOCKER_TAG}" | sed -r 's/[^a-zA-Z0-9_.-]/-/g')
 machinepath="${TOOLBOX_DIRECTORY}/${machinename}"
 osrelease="${machinepath}/etc/os-release"
 if [ ! -f ${osrelease} ] || systemctl is-failed -q ${machinename} ; then


### PR DESCRIPTION
Right now machine names get messy names like `core-account_my-special-toolbox-latest`, much better would be `core-account-my-special-toolbox-latest`.