### PR TITLE
Enhancement - Allow toolbox partition binding to be overridden

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -33,5 +33,5 @@ sudo systemd-nspawn \
 	--directory="${machinepath}" \
 	--capability=all \
 	--share-system \
-        "${TOOLBOX_BIND} \
+        "${TOOLBOX_BIND}" \
 	--user="${TOOLBOX_USER}" "$@"

--- a/toolbox
+++ b/toolbox
@@ -7,6 +7,7 @@ TOOLBOX_DOCKER_IMAGE=fedora
 TOOLBOX_DOCKER_TAG=latest
 TOOLBOX_USER=root
 TOOLBOX_DIRECTORY="/var/lib/toolbox"
+TOOLBOX_BIND="--bind=/:/media/root --bind=/usr:/media/root/usr --bind=/run:/media/root/run"
 
 toolboxrc="${HOME}"/.toolboxrc
 
@@ -32,7 +33,5 @@ sudo systemd-nspawn \
 	--directory="${machinepath}" \
 	--capability=all \
 	--share-system \
-	--bind=/:/media/root \
-	--bind=/usr:/media/root/usr \
-	--bind=/run:/media/root/run \
+        "${TOOLBOX_BIND} \
 	--user="${TOOLBOX_USER}" "$@"


### PR DESCRIPTION
Toolbox currently has fixed bind options when starting the container. Ideally when using tool like sysdig which expect host paths to be mounted in set locations it would be ideal to be able to override the default bind location.

This patch changes the bind mount to a variable that could then be overridden.