### PR TITLE
allow custom environment vars

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -8,6 +8,8 @@ TOOLBOX_DOCKER_TAG=latest
 TOOLBOX_USER=root
 TOOLBOX_DIRECTORY="/var/lib/toolbox"
 TOOLBOX_BIND="--bind=/:/media/root --bind=/usr:/media/root/usr --bind=/run:/media/root/run"
+# Ex: "--setenv=KEY=VALUE"
+TOOLBOX_ENV=""
 
 toolboxrc="${HOME}"/.toolboxrc
 
@@ -34,4 +36,5 @@ sudo systemd-nspawn \
 	--capability=all \
 	--share-system \
         ${TOOLBOX_BIND} \
+        ${TOOLBOX_ENV} \
 	--user="${TOOLBOX_USER}" "$@"

--- a/toolbox
+++ b/toolbox
@@ -13,6 +13,12 @@ TOOLBOX_ENV=""
 
 toolboxrc="${HOME}"/.toolboxrc
 
+# System defaults
+if [ -f "/etc/default/toolbox" ]; then
+	source "/etc/default/toolbox"
+fi
+
+# User overrides
 if [ -f "${toolboxrc}" ]; then
 	source "${toolboxrc}"
 fi


### PR DESCRIPTION
Allow users to set custom environment vars. This is useful when
toolbox is used with custom TOOLBOX_DOCKER_IMAGE. Since toolbox
doesn't recognize the 'ENV' lines from Dockerfile of the image.
Also, add the ability to provide system-wide defaults.