### PR TITLE
default to Fedora 24

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 TOOLBOX_DOCKER_IMAGE=fedora
-TOOLBOX_DOCKER_TAG=latest
+TOOLBOX_DOCKER_TAG=24
 TOOLBOX_USER=root
 TOOLBOX_DIRECTORY="/var/lib/toolbox"
 TOOLBOX_BIND="--bind=/:/media/root --bind=/usr:/media/root/usr --bind=/run:/media/root/run"


### PR DESCRIPTION
Using 24 works around a bug in 25 that prevents `dnf` from working unless you import the Fedora GPG key, which is hard to instruct users to do due to the interactive nature of toolbox

cc: @dm0- 