### PR TITLE
Add arm64 support

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -3,8 +3,22 @@
 set -e
 set -o pipefail
 
-TOOLBOX_DOCKER_IMAGE=fedora
-TOOLBOX_DOCKER_TAG=24
+machine=$(uname -m)
+
+case ${machine} in
+	aarch64 )
+		TOOLBOX_NAME=fedora-base-24-1.1.aarch64
+		TOOLBOX_DOCKER_ARCHIVE="https://dl.fedoraproject.org/pub/fedora-secondary/releases/24/Docker/aarch64/images/Fedora-Docker-Base-24-1.1.aarch64.tar.xz"
+		;;
+	x86_64 )
+		TOOLBOX_DOCKER_IMAGE=fedora
+		TOOLBOX_DOCKER_TAG=24
+		;;
+	* )
+		echo "Warning: Unknown machine type ${machine}" >&2
+		;;
+esac
+
 TOOLBOX_USER=root
 TOOLBOX_DIRECTORY="/var/lib/toolbox"
 TOOLBOX_BIND="--bind=/:/media/root --bind=/usr:/media/root/usr --bind=/run:/media/root/run"
@@ -23,16 +37,34 @@ if [ -f "${toolboxrc}" ]; then
 	source "${toolboxrc}"
 fi
 
-machinename=$(echo "${USER}-${TOOLBOX_DOCKER_IMAGE}-${TOOLBOX_DOCKER_TAG}" | sed -r 's/[^a-zA-Z0-9_.-]/_/g')
+if [[ -n "${TOOLBOX_DOCKER_IMAGE}" ]] && [[ -n "${TOOLBOX_DOCKER_TAG}" ]]; then
+	TOOLBOX_NAME=${TOOLBOX_DOCKER_IMAGE}-${TOOLBOX_DOCKER_TAG}
+	have_docker_image="y"
+fi
+
+machinename=$(echo "${USER}-${TOOLBOX_NAME}" | sed -r 's/[^a-zA-Z0-9_.-]/_/g')
 machinepath="${TOOLBOX_DIRECTORY}/${machinename}"
 osrelease="${machinepath}/etc/os-release"
 if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 	sudo mkdir -p "${machinepath}"
 	sudo chown "${USER}:" "${machinepath}"
 
-	riid=$(sudo rkt --insecure-options=image fetch "docker://${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
-	sudo rkt image extract --overwrite --rootfs-only "${riid}" "${machinepath}"
-	sudo rkt image rm "${riid}"
+	if [[ -n "${have_docker_image}" ]]; then
+		riid=$(sudo rkt --insecure-options=image fetch "docker://${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
+		sudo rkt image extract --overwrite --rootfs-only "${riid}" "${machinepath}"
+		sudo rkt image rm "${riid}"
+	elif [[ -n "${TOOLBOX_DOCKER_ARCHIVE}" ]]; then
+		tmpdir=$(mktemp -d -p /var/tmp/)
+		trap "sudo rm -rf ${tmpdir}" EXIT PIPE
+		wget -O- "${TOOLBOX_DOCKER_ARCHIVE}" | xz -cd | tar -C ${tmpdir} -xf -
+		layer=$(find ${tmpdir} -name layer.tar -type f)
+		sudo tar -C ${machinepath} -xf ${layer}
+		trap - EXIT PIPE
+		sudo rm -rf ${tmpdir}
+	else
+		echo "Error: No toolbox filesystem specified." >&2
+		exit 1
+	fi
 	sudo touch "${osrelease}"
 fi
 

--- a/toolbox
+++ b/toolbox
@@ -30,9 +30,9 @@ if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 	sudo mkdir -p "${machinepath}"
 	sudo chown "${USER}:" "${machinepath}"
 
-	riid=$(rkt --insecure-options=image fetch "docker://${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
+	riid=$(sudo rkt --insecure-options=image fetch "docker://${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
 	sudo rkt image extract --overwrite --rootfs-only "${riid}" "${machinepath}"
-	rkt image rm "${riid}"
+	sudo rkt image rm "${riid}"
 	sudo touch "${osrelease}"
 fi
 


### PR DESCRIPTION
Use an arm64 docker image when running on an arm64 machine.

No official arm64 Fedora docker image is currently available, so use an
Ubuntu image.

Fixes https://github.com/coreos/bugs/issues/1754 (/usr/bin/toolbox fails on ARMv8 with "execv() failed: Exec format error" on 1235.2.0/ARMv8).
