### PR TITLE
Update the image and support environment variables

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -7,12 +7,12 @@ machine=$(uname -m)
 
 case ${machine} in
 	aarch64 )
-		TOOLBOX_NAME=fedora-base-24-1.1.aarch64
-		TOOLBOX_DOCKER_ARCHIVE="https://dl.fedoraproject.org/pub/fedora-secondary/releases/24/Docker/aarch64/images/Fedora-Docker-Base-24-1.1.aarch64.tar.xz"
+		TOOLBOX_DOCKER_IMAGE=aarch64/fedora
+		TOOLBOX_DOCKER_TAG=latest
 		;;
 	x86_64 )
 		TOOLBOX_DOCKER_IMAGE=fedora
-		TOOLBOX_DOCKER_TAG=24
+		TOOLBOX_DOCKER_TAG=latest
 		;;
 	* )
 		echo "Warning: Unknown machine type ${machine}" >&2

--- a/toolbox
+++ b/toolbox
@@ -50,9 +50,9 @@ if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 	sudo chown "${USER}:" "${machinepath}"
 
 	if [[ -n "${have_docker_image}" ]]; then
-		riid=$(sudo rkt --insecure-options=image fetch "docker://${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
-		sudo rkt image extract --overwrite --rootfs-only "${riid}" "${machinepath}"
-		sudo rkt image rm "${riid}"
+		riid=$(sudo --preserve-env rkt --insecure-options=image fetch "docker://${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
+		sudo --preserve-env rkt image extract --overwrite --rootfs-only "${riid}" "${machinepath}"
+		sudo --preserve-env rkt image rm "${riid}"
 	elif [[ -n "${TOOLBOX_DOCKER_ARCHIVE}" ]]; then
 		tmpdir=$(mktemp -d -p /var/tmp/)
 		trap "sudo rm -rf ${tmpdir}" EXIT PIPE


### PR DESCRIPTION
Since systemd v233 fixed the SIGKILL problems, use Fedora's latest image again.

And proxy environment variables were blocked from `rkt` by `sudo`, so explicitly pass them through.

This fixes coreos/bugs#1869.