### PR TITLE
toolbox: make toolbox understand the -c shell command option

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -68,6 +68,11 @@ if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 	sudo touch "${osrelease}"
 fi
 
+# Special case for when SSH tries to pass a shell command with -c
+if [ "x${1-}" == x-c ]; then
+	set /bin/sh "$@"
+fi
+
 sudo systemd-nspawn \
 	--directory="${machinepath}" \
 	--capability=all \


### PR DESCRIPTION
This is a workaround for when toolbox is used as a login shell, and that user then passes a command directly to SSH.  SSH handles the situation by calling "toolbox -c 'the whole command'", which can be used by passing arguments to a POSIX shell in the toolbox container (and hoping the user didn't pick a container without one).

This fixes coreos/bugs#899.