### PR TITLE
Add toolbox script for RHCOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 toolbox is a small script that launches a container to let you bring in your favorite debugging or admin tools.
 
+There are currently two scripts that live within this repository:
+ - toolbox: designed for Container Linux, uses rkt and systemd-nspawn
+ - rhcos-toolbox: designed for Red Hat CoreOS, uses podman
+
 ## Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ listening on ens3, link-type EN10MB (Ethernet), capture size 65535 bytes
 
 toolbox uses a Fedora-based userspace environment by default, but this can be changed to any Docker image. Simply override environment variables in `$HOME/.toolboxrc`:
 
+#### toolbox
+
 ```
 core@core-01 ~ $ cat ~/.toolboxrc
 TOOLBOX_DOCKER_IMAGE=ubuntu-debootstrap
@@ -33,6 +35,16 @@ core@core-01 ~ $ toolbox
 Spawning container core-ubuntu-debootstrap-14.04 on /var/lib/toolbox/core-ubuntu-debootstrap-14.04.
 Press ^] three times within 1s to kill container.
 root@core-01:~# apt-get update && apt-get install tcpdump
+```
+
+#### rhcos-toolbox
+
+```
+core@core-01 ~ $ cat ~/.toolboxrc
+REGISTRY=registry.redhat.io
+IMAGE=rhel7/rhel-tools:latest
+core@core-01 ~ $ toolbox
+Spawning a container 'toolbox-test' with image 'registry.redhat.io/rhel7/rhel-tools:latest'
 ```
 
 ### Automatically enter toolbox on login

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -61,13 +61,13 @@ image_exists() {
 
 image_pull() {
     if ! sudo podman pull "$TOOLBOX_IMAGE"; then
-        read -r -n 1 -p "Would you like to authenticate to registry: '${REGISTRY}' and try again? [y/N] "
-        echo
+        read -r -p "Would you like to authenticate to registry: '${REGISTRY}' and try again? [y/N] "
 
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
+        if [[ $REPLY =~ ^([Yy][Ee][Ss]|[Yy])+$ ]]; then
             sudo podman login "${REGISTRY}"
             sudo podman pull "$TOOLBOX_IMAGE"
         else
+            echo "Exiting..."
             exit 1
         fi
     fi
@@ -110,7 +110,7 @@ main() {
     cleanup
 }
 
-if [ -z "$1" ]; then
+if [ ! -n "$*" ]; then
     set /bin/sh "$@"
 fi
 

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -4,7 +4,8 @@ set -eo pipefail
 trap cleanup EXIT
 
 setup() {
-    TOOLBOX_IMAGE=registry.fedoraproject.org/fedora:latest
+    REGISTRY=registry.fedoraproject.org
+    IMAGE=fedora:latest
     TOOLBOX_NAME=toolbox-"${USER}"
 
     # Allow user overrides
@@ -14,9 +15,14 @@ setup() {
         echo ".toolboxrc file detected, overriding defaults..."
         source "${toolboxrc}"
     fi
+    TOOLBOX_IMAGE="${REGISTRY}"/"${IMAGE}"
 }
 
 run() {
+    if ! image_exists; then
+        image_pull
+    fi
+
     if ! container_exists; then
         echo "Spawning a container '$TOOLBOX_NAME' with image '$TOOLBOX_IMAGE'"
         container_create
@@ -47,6 +53,24 @@ container_exists() {
 
 container_state() {
     sudo podman inspect "$TOOLBOX_NAME" --format '{{.State.Status}}'
+}
+
+image_exists() {
+    sudo podman inspect "$TOOLBOX_IMAGE" &>/dev/null
+}
+
+image_pull() {
+    if ! sudo podman pull "$TOOLBOX_IMAGE"; then
+        read -r -n 1 -p "Would you like to authenticate to registry: '${REGISTRY}' and try again? [y/N] "
+        echo
+
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            sudo podman login "${REGISTRY}"
+            sudo podman pull "$TOOLBOX_IMAGE"
+        else
+            exit 1
+        fi
+    fi
 }
 
 container_create() {

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -eo pipefail
+
+trap cleanup EXIT
+
+setup() {
+    TOOLBOX_IMAGE=registry.fedoraproject.org/fedora:latest
+    TOOLBOX_NAME=toolbox-"${USER}"
+
+    # Allow user overrides
+
+    toolboxrc="${HOME}"/.toolboxrc
+    if [ -f "${toolboxrc}" ]; then
+        echo ".toolboxrc file detected, overriding defaults..."
+        source "${toolboxrc}"
+    fi
+}
+
+run() {
+    if ! container_exists; then
+        echo "Spawning a container '$TOOLBOX_NAME' with image '$TOOLBOX_IMAGE'"
+        container_create
+    else
+        echo "Container '$TOOLBOX_NAME' already exists. Starting..."
+        echo "(To remove the container and start with a fresh toolbox, run: sudo podman rm '$TOOLBOX_NAME')"
+    fi
+
+    local state=$(container_state)
+    if [[ "$state" == configured ]] || [[ "$state" == exited ]]; then
+        container_start
+    elif [[ "$state" != running ]]; then
+        echo "Container '$TOOLBOX_NAME' in unknown state: '$state'"
+        return 1
+    fi
+
+    echo "Container started successfully."
+    container_exec "$@"
+}
+
+cleanup() {
+    sudo podman stop "$TOOLBOX_NAME" &>/dev/null
+}
+
+container_exists() {
+    sudo podman inspect "$TOOLBOX_NAME" &>/dev/null
+}
+
+container_state() {
+    sudo podman inspect "$TOOLBOX_NAME" --format '{{.State.Status}}'
+}
+
+container_create() {
+    if ! sudo podman create \
+                 --hostname toolbox \
+                 --name "$TOOLBOX_NAME" \
+                 --network host \
+                 --privileged \
+                 --security-opt label=disable \
+                 --tty \
+                 --volume /:/media/root:rslave \
+                 "$TOOLBOX_IMAGE" 2>&1; then
+        echo "$0: failed to create container '$TOOLBOX_NAME'"
+        exit 1
+    fi
+}
+
+container_start() {
+    if ! sudo podman start "$TOOLBOX_NAME" 2>&1; then
+        echo "$0: failed to start container '$TOOLBOX_NAME'"
+        exit 1
+    fi
+}
+
+container_exec() {
+    sudo podman exec \
+            --env LANG="$LANG" \
+            --env TERM="$TERM" \
+            --tty \
+            "$TOOLBOX_NAME" \
+            "$@"
+}
+
+main() {
+    setup
+    run "$@"
+    cleanup
+}
+
+if [ -z "$1" ]; then
+    set /bin/sh "$@"
+fi
+
+main "$@"

--- a/rhcos-toolbox.spec
+++ b/rhcos-toolbox.spec
@@ -1,0 +1,36 @@
+Name:		toolbox
+Version:	0.0.1
+Release:	1%{?dist}
+Summary:	script to launch privileged container with podman
+
+License:	ASLv2.0
+URL:		https://github.com/coreos/toolbox
+Source0:	https://github.com/coreos/%{name}/archive/%{version}.tar.gz
+Requires:	podman
+
+%description
+toolbox is a small script that launches a container to let
+you bring in your favorite debugging or admin tools.
+
+%define debug_package %{nil}
+
+%prep
+%autosetup
+
+%build
+# No building required
+
+%install
+rm -rf $RPM_BUILD_ROOT
+install -d $RPM_BUILD_ROOT/%{_bindir}
+install -m 755 rhcos-toolbox $RPM_BUILD_ROOT/%{_bindir}/toolbox
+
+%files
+%license LICENSE
+%doc README.md NOTICE
+%{_bindir}/toolbox
+
+
+%changelog
+* Thu Sep 6 2018 Yu Qi Zhang <jerzhang@redhat.com> - 0.0.1
+- Initial Specfile for Red Hat CoreOS Toolbox


### PR DESCRIPTION
Add rhcos-toolbox and corresponding specfile for building wtih rdgo.
rhcos-toolbox is a script that makes use of podman to create a
privileged debug/admin container, with ability to handle user
defined commands and variables. Modify README to reflect the change.