### PR TITLE
github: add issue reporting templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Report an issue with toolbox
+---
+
+# Bug #
+
+## Host Operating System Version ##
+
+## Environment ##
+
+What hardware/cloud provider/hypervisor is being used to run toolbox?
+
+## Expected Behavior ##
+
+## Actual Behavior ##
+
+## Reproduction Steps ##
+
+  1. ...
+  2. ...
+
+## Other Information ##

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an enhancement to toolbox
+---
+
+# Feature Request #
+
+## Environment ##
+
+What hardware/cloud provider/hypervisor is being used to run toolbox?
+
+## Desired Feature ##
+
+## Other Information ##


### PR DESCRIPTION
This will cause GitHub's "New issue" button to redirect to a template chooser.