### PR TITLE
$TOOLBOX_DOCKER_ARCHIVE variable removed

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -53,14 +53,6 @@ if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 		riid=$(sudo --preserve-env rkt --insecure-options=image fetch "docker://${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
 		sudo --preserve-env rkt image extract --overwrite --rootfs-only "${riid}" "${machinepath}"
 		sudo --preserve-env rkt image rm "${riid}"
-	elif [[ -n "${TOOLBOX_DOCKER_ARCHIVE}" ]]; then
-		tmpdir=$(mktemp -d -p /var/tmp/)
-		trap "sudo rm -rf ${tmpdir}" EXIT PIPE
-		wget -O- "${TOOLBOX_DOCKER_ARCHIVE}" | xz -cd | tar -C ${tmpdir} -xf -
-		layer=$(find ${tmpdir} -name layer.tar -type f)
-		sudo tar -C ${machinepath} -xf ${layer}
-		trap - EXIT PIPE
-		sudo rm -rf ${tmpdir}
 	else
 		echo "Error: No toolbox filesystem specified." >&2
 		exit 1


### PR DESCRIPTION
The `TOOLBOX_DOCKER_ARCHIVE` variable is not referenced anywhere in the source code. It is a leftover from the earlier [commit](https://github.com/coreos/toolbox/commit/b5bebb3fdd8982c95ccbb1772bc126c76758a7ed#diff-0e842b75e5f8473161ee799ef5a129fd) that replaced it with  `TOOLBOX_DOCKER_IMAGE`.

It also is useless as Fedora has discontinued the archive repository in favor of container images.