### PR TITLE
toolbox: Switch --share-system to the environment

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -73,10 +73,9 @@ if [ "x${1-}" == x-c ]; then
 	set /bin/sh "$@"
 fi
 
-sudo systemd-nspawn \
+sudo SYSTEMD_NSPAWN_SHARE_SYSTEM=1 systemd-nspawn \
 	--directory="${machinepath}" \
 	--capability=all \
-	--share-system \
         ${TOOLBOX_BIND} \
         ${TOOLBOX_ENV} \
 	--user="${TOOLBOX_USER}" "$@"


### PR DESCRIPTION
Since the last systemd update, nspawn now warns about using the `--share-system` option.  Instead switch to the catch-all environment variable which has the same effect.