### PR TITLE
rhcos-toolbox: use interactive flag for exec

### DIFF
--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -118,6 +118,7 @@ container_exec() {
             --env LANG="$LANG" \
             --env TERM="$TERM" \
             --tty \
+            --interactive \
             "$TOOLBOX_NAME" \
             "$@"
 }


### PR DESCRIPTION
After the initial execution of toolbox, subsequent executions
would fail because the interactive flag is missing.  The user is
left with a shell prompt but cannot type anything.