### PR TITLE
rhcos-toolbox: Ignore podman '<no value>' output for empty labels

### DIFF
--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -26,7 +26,7 @@ run() {
     local runlabel=$(image_runlabel)
     if ! container_exists; then
         echo "Spawning a container '$TOOLBOX_NAME' with image '$TOOLBOX_IMAGE'"
-        if [[ -z "$runlabel" ]]; then
+        if [[ -z "$runlabel" ]] || [[ "$runlabel" == "<no value>" ]]; then
             container_run
             return
         else


### PR DESCRIPTION
podman displays '\<no value\>' when a label is not set for a container
image.

Fixes: https://github.com/coreos/toolbox/commit/a6d2ecf4d4d7f2c5313f8c0807197f0949f6ea16
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1924020