### PR TITLE
rhcos-toolbox: check for an empty RUN label

### DIFF
--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -68,8 +68,9 @@ image_exists() {
 }
 
 image_runlabel() {
-    sudo podman image inspect "$TOOLBOX_IMAGE" --format "{{.Labels.run}}"
+    sudo podman image inspect "$TOOLBOX_IMAGE" --format '{{- if index .Labels "run" -}}{{.Labels.run}}{{- end -}}'
 }
+
 
 image_pull() {
     if ! sudo --preserve-env podman pull --authfile /var/lib/kubelet/config.json "$TOOLBOX_IMAGE"; then


### PR DESCRIPTION
`podman` returns `<no value>` when inspecting a label that does not
exist. That string is interpreted as the presence of a RUN label, so
we try to start the container with a non-existent RUN label. Use some
go formatting to return an empty string when the label is empty.

We've somehow avoided this until it was reported in RHBZ#2048789.

Co-authored-by: Jonathan Lebon <jonathan@jlebon.com>