### PR TITLE
Improvements to authfile handling, podman inspect, variable formats

### DIFF
--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -6,6 +6,7 @@ trap cleanup EXIT
 # Defaults
 REGISTRY=registry.redhat.io
 IMAGE=rhel8/support-tools
+AUTHFILE=/var/lib/kubelet/config.json
 TOOLBOX_NAME=toolbox-"$(whoami)"
 TOOLBOXRC="${HOME}"/.toolboxrc
 
@@ -33,8 +34,8 @@ run() {
 
     local runlabel=$(image_runlabel)
     if ! container_exists; then
-        echo "Spawning a container '$TOOLBOX_NAME' with image '$TOOLBOX_IMAGE'"
-        if [[ -z "$runlabel" ]] || [[ "$runlabel" == "<no value>" ]]; then
+        echo "Spawning a container '${TOOLBOX_NAME}' with image '${TOOLBOX_IMAGE}'"
+        if [[ -z "${runlabel}" ]] || [[ "${runlabel}" == "<no value>" ]]; then
             container_create
         else
             echo "Detected RUN label in the container image. Using that as the default..."
@@ -77,7 +78,7 @@ image_exists() {
 # registry. (or if we couldn't inspect the registry successfully)
 image_fresh() {
     local_date=$(sudo podman inspect "$TOOLBOX_IMAGE" --format '{{.Created}}')
-    if ! remote_date=$(sudo skopeo inspect --authfile /var/lib/kubelet/config.json docker://"$TOOLBOX_IMAGE" --format '{{.Created}}'); then
+    if ! remote_date=$(sudo skopeo inspect --authfile "$AUTHFILE" docker://"$TOOLBOX_IMAGE" --format '{{.Created}}'); then
         echo "Error inspecting $TOOLBOX_IMAGE via skopeo"
         return
     fi
@@ -93,12 +94,12 @@ image_runlabel() {
 
 
 image_pull() {
-    if ! sudo --preserve-env podman pull --authfile /var/lib/kubelet/config.json "$TOOLBOX_IMAGE"; then
+    if ! sudo --preserve-env podman pull --authfile "${AUTHFILE}" "$TOOLBOX_IMAGE"; then
         read -r -p "Would you like to manually authenticate to registry: '${REGISTRY}' and try again? [y/N] "
 
         if [[ $REPLY =~ ^([Yy][Ee][Ss]|[Yy])+$ ]]; then
-            sudo --preserve-env podman login "${REGISTRY}"
-            sudo --preserve-env podman pull "$TOOLBOX_IMAGE"
+            sudo --preserve-env podman login --authfile "${AUTHFILE}" "${REGISTRY}"
+            sudo --preserve-env podman pull --authfile "${AUTHFILE}" "$TOOLBOX_IMAGE"
         else
             echo "Exiting..."
             exit 1
@@ -188,11 +189,13 @@ You may override the following variables by setting them in ${TOOLBOXRC}:
 - REGISTRY: The registry to pull from. Default: $REGISTRY
 - IMAGE: The image and tag from the registry to pull. Default: $IMAGE
 - TOOLBOX_NAME: The name to use for the local container. Default: $TOOLBOX_NAME
+- AUTHFILE: The location where your registry credentials are stored. Default: ${AUTHFILE}
 
 Example toolboxrc:
 REGISTRY=my.special.registry.example.com
 IMAGE=debug:latest
-TOOLBOX_NAME=special-debug-container"
+TOOLBOX_NAME=special-debug-container
+AUTHFILE=/home/core/.docker/config.json"
 }
 
 main() {

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -28,7 +28,7 @@ run() {
     elif ! image_fresh; then
         read -r -p "There is a newer version of ${TOOLBOX_IMAGE} available. Would you like to pull it? [y/N] "
 
-        if [[ $REPLY =~ ^([Yy][Ee][Ss]|[Yy])+$ ]]; then
+        if [[ ${REPLY} =~ ^([Yy][Ee][Ss]|[Yy])+$ ]]; then
             image_pull
             if container_exists; then
                 sudo podman rm "${TOOLBOX_NAME}"
@@ -48,15 +48,15 @@ run() {
             container_create_runlabel
         fi
     else
-        echo "Container '$TOOLBOX_NAME' already exists. Trying to start..."
-        echo "(To remove the container and start with a fresh toolbox, run: sudo podman rm '$TOOLBOX_NAME')"
+        echo "Container '${TOOLBOX_NAME}' already exists. Trying to start..."
+        echo "(To remove the container and start with a fresh toolbox, run: sudo podman rm '${TOOLBOX_NAME}')"
     fi
 
     local state=$(container_state)
-    if [[ "$state" == configured ]] || [[ "$state" == exited ]] || [[ "$state" == stopped ]]; then
+    if [[ "${state}" == configured ]] || [[ "${state}" == exited ]] || [[ "${state}" == stopped ]]; then
         container_start
-    elif [[ "$state" != running ]]; then
-        echo "Container '$TOOLBOX_NAME' in unknown state: '$state'"
+    elif [[ "${state}" != running ]]; then
+        echo "Container '${TOOLBOX_NAME}' in unknown state: '$state'"
         return 1
     fi
 
@@ -67,7 +67,7 @@ run() {
 }
 
 cleanup() {
-    sudo podman stop "$TOOLBOX_NAME" &>/dev/null
+    sudo podman stop "${TOOLBOX_NAME}" &>/dev/null
 }
 
 container_exists() {
@@ -99,17 +99,17 @@ image_fresh() {
 }
 
 image_runlabel() {
-    sudo podman image inspect "$TOOLBOX_IMAGE" --format '{{- if index .Labels "run" -}}{{.Labels.run}}{{- end -}}'
+    sudo podman image inspect "${TOOLBOX_IMAGE}" --format '{{- if index .Labels "run" -}}{{.Labels.run}}{{- end -}}'
 }
 
 
 image_pull() {
-    if ! sudo --preserve-env podman pull --authfile "${AUTHFILE}" "$TOOLBOX_IMAGE"; then
+    if ! sudo --preserve-env podman pull --authfile "${AUTHFILE}" "${TOOLBOX_IMAGE}"; then
         read -r -p "Would you like to manually authenticate to registry: '${REGISTRY}' and try again? [y/N] "
 
-        if [[ $REPLY =~ ^([Yy][Ee][Ss]|[Yy])+$ ]]; then
+        if [[ ${REPLY} =~ ^([Yy][Ee][Ss]|[Yy])+$ ]]; then
             sudo --preserve-env podman login --authfile "${AUTHFILE}" "${REGISTRY}"
-            sudo --preserve-env podman pull --authfile "${AUTHFILE}" "$TOOLBOX_IMAGE"
+            sudo --preserve-env podman pull --authfile "${AUTHFILE}" "${TOOLBOX_IMAGE}"
         else
             echo "Exiting..."
             exit 1
@@ -120,7 +120,7 @@ image_pull() {
 container_create() {
     if ! sudo podman create \
         --hostname toolbox \
-        --name "$TOOLBOX_NAME" \
+        --name "${TOOLBOX_NAME}" \
         --privileged \
         --net=host \
         --pid=host \
@@ -128,23 +128,23 @@ container_create() {
         --tty \
         --interactive \
         -e HOST=/host \
-        -e NAME="$TOOLBOX_NAME" \
-        -e IMAGE="$IMAGE" \
+        -e NAME="${TOOLBOX_NAME}" \
+        -e IMAGE="${IMAGE}" \
         --security-opt label=disable \
         --volume /run:/run \
         --volume /var/log:/var/log \
         --volume /etc/machine-id:/etc/machine-id \
         --volume /etc/localtime:/etc/localtime \
         --volume /:/host \
-        "$TOOLBOX_IMAGE" 2>&1; then
-        echo "$0: failed to create container '$TOOLBOX_NAME'"
+        "${TOOLBOX_IMAGE}" 2>&1; then
+        echo "$0: failed to create container '${TOOLBOX_NAME}'"
         exit 1
     fi
 }
 
 container_start() {
-    if ! sudo podman start "$TOOLBOX_NAME" 2>&1; then
-        echo "$0: failed to start container '$TOOLBOX_NAME'"
+    if ! sudo podman start "${TOOLBOX_NAME}" 2>&1; then
+        echo "$0: failed to start container '${TOOLBOX_NAME}'"
         exit 1
     fi
 }
@@ -153,14 +153,14 @@ container_create_runlabel() {
     # Variable replacement logic reproduced from:
     # https://github.com/containers/podman/blob/29d7ab3f82e38c442e449739e218349b9a4a16ea/pkg/domain/infra/abi/containers_runlabel.go#L226
     local pod
-    pod="$(echo "$runlabel" \
+    pod="$(echo "${runlabel}" \
         | sed 's/podman run/sudo podman create/' \
-        | sed 's/--name NAME/--name $TOOLBOX_NAME/' \
-        | sed 's/NAME=NAME/NAME=$TOOLBOX_NAME/' \
-        | sed 's/IMAGE=IMAGE/IMAGE=$TOOLBOX_IMAGE/' \
-        | sed 's/host IMAGE/host $TOOLBOX_IMAGE/')"
-    if ! eval "$pod" ; then
-        echo "$0: failed to create container from runlabel '$TOOLBOX_NAME'"
+        | sed 's/--name NAME/--name ${TOOLBOX_NAME}/' \
+        | sed 's/NAME=NAME/NAME=${TOOLBOX_NAME}/' \
+        | sed 's/IMAGE=IMAGE/IMAGE=${TOOLBOX_IMAGE}/' \
+        | sed 's/host IMAGE/host ${TOOLBOX_IMAGE}/')"
+    if ! eval "${pod}" ; then
+        echo "$0: failed to create container from runlabel '${TOOLBOX_NAME}'"
         exit 1
     fi
 }
@@ -169,19 +169,19 @@ container_exec() {
     if [[ "$#" -eq 0 ]]; then
         cmd=$(sudo podman image inspect "${TOOLBOX_IMAGE}" | jq -re ".[].Config.Cmd[0]") || cmd="/bin/sh"
         sudo podman exec \
-            --env LANG="$LANG" \
-            --env TERM="$TERM" \
+            --env LANG="${LANG}" \
+            --env TERM="${TERM}" \
             --tty \
             --interactive \
-            "$TOOLBOX_NAME" \
-            "$cmd"
+            "${TOOLBOX_NAME}" \
+            "${cmd}"
     else
         sudo podman exec \
-            --env LANG="$LANG" \
-            --env TERM="$TERM" \
+            --env LANG="${LANG}" \
+            --env TERM="${TERM}" \
             --tty \
             --interactive \
-            "$TOOLBOX_NAME" \
+            "${TOOLBOX_NAME}" \
             "$@"
     fi
 }
@@ -196,9 +196,9 @@ Options:
   -h/--help: Shows this help message
 
 You may override the following variables by setting them in ${TOOLBOXRC}:
-- REGISTRY: The registry to pull from. Default: $REGISTRY
-- IMAGE: The image and tag from the registry to pull. Default: $IMAGE
-- TOOLBOX_NAME: The name to use for the local container. Default: $TOOLBOX_NAME
+- REGISTRY: The registry to pull from. Default: ${REGISTRY}
+- IMAGE: The image and tag from the registry to pull. Default: ${IMAGE}
+- TOOLBOX_NAME: The name to use for the local container. Default: ${TOOLBOX_NAME}
 - AUTHFILE: The location where your registry credentials are stored. Default: ${AUTHFILE}
 
 Example toolboxrc:

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -22,11 +22,17 @@ setup() {
 run() {
     if ! image_exists; then
         image_pull
+        if container_exists; then
+            sudo podman rm "${TOOLBOX_NAME}"
+        fi
     elif ! image_fresh; then
         read -r -p "There is a newer version of ${TOOLBOX_IMAGE} available. Would you like to pull it? [y/N] "
 
         if [[ $REPLY =~ ^([Yy][Ee][Ss]|[Yy])+$ ]]; then
             image_pull
+            if container_exists; then
+                sudo podman rm "${TOOLBOX_NAME}"
+            fi
         else
             echo "Skipping retrieval of new image.."
         fi

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -63,23 +63,24 @@ cleanup() {
 }
 
 container_exists() {
-    sudo podman inspect "$TOOLBOX_NAME" &>/dev/null
+    sudo podman container inspect "${TOOLBOX_NAME}" &>/dev/null
 }
 
 container_state() {
-    sudo podman inspect "$TOOLBOX_NAME" --format '{{.State.Status}}'
+    sudo podman container inspect "${TOOLBOX_NAME}" --format '{{.State.Status}}'
 }
 
 image_exists() {
-    sudo podman inspect "$TOOLBOX_IMAGE" &>/dev/null
+    sudo podman image inspect "${TOOLBOX_IMAGE}" &>/dev/null
 }
 
 # returns 0 if the image on disk is "fresh", i.e. no newer image on remote
 # registry. (or if we couldn't inspect the registry successfully)
 image_fresh() {
-    local_date=$(sudo podman inspect "$TOOLBOX_IMAGE" --format '{{.Created}}')
-    if ! remote_date=$(sudo skopeo inspect --authfile "$AUTHFILE" docker://"$TOOLBOX_IMAGE" --format '{{.Created}}'); then
-        echo "Error inspecting $TOOLBOX_IMAGE via skopeo"
+    echo "Checking if there is a newer version of ${TOOLBOX_IMAGE} available..."
+    local_date=$(sudo podman image inspect "${TOOLBOX_IMAGE}" --format '{{.Created}}')
+    if ! remote_date=$(sudo skopeo inspect --authfile "${AUTHFILE}" docker://"${TOOLBOX_IMAGE}" --format '{{.Created}}'); then
+        echo "Error inspecting ${TOOLBOX_IMAGE} via skopeo"
         return
     fi
     # if the date on the registry is *NOT* newer than the local image date
@@ -157,7 +158,7 @@ container_create_runlabel() {
 
 container_exec() {
     if [[ "$#" -eq 0 ]]; then
-        cmd=$(sudo podman inspect "$TOOLBOX_IMAGE" | jq -re ".[].Config.Cmd[0]") || cmd="/bin/sh"
+        cmd=$(sudo podman image inspect "${TOOLBOX_IMAGE}" | jq -re ".[].Config.Cmd[0]") || cmd="/bin/sh"
         sudo podman exec \
             --env LANG="$LANG" \
             --env TERM="$TERM" \

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -60,7 +60,9 @@ run() {
         return 1
     fi
 
-    echo "Container started successfully. To exit, type 'exit'."
+    if [[ "$#" -eq "0" ]]; then
+        echo "Container started successfully. To exit, type 'exit'."
+    fi
     container_exec "$@"
 }
 
@@ -85,6 +87,7 @@ image_exists() {
 image_fresh() {
     echo "Checking if there is a newer version of ${TOOLBOX_IMAGE} available..."
     local_date=$(sudo podman image inspect "${TOOLBOX_IMAGE}" --format '{{.Created}}')
+
     if ! remote_date=$(sudo skopeo inspect --authfile "${AUTHFILE}" docker://"${TOOLBOX_IMAGE}" --format '{{.Created}}'); then
         echo "Error inspecting ${TOOLBOX_IMAGE} via skopeo"
         return


### PR DESCRIPTION
This is a pile of improvements that started with just fixing how we handle the authfile, but has grown to things like:

- removing existing containers when new container image is used
- being specific about `podman container inspect` and `podman image inspect`
- normalizing the use of `${var}` format

See the individual commits for more details.