### PR TITLE
Bug 2093040: Unable to start `toolbox` on RHCOS using `podman` 4.0

### DIFF
--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -53,7 +53,7 @@ run() {
     fi
 
     local state=$(container_state)
-    if [[ "${state}" == configured ]] || [[ "${state}" == exited ]] || [[ "${state}" == stopped ]]; then
+    if [[ "${state}" == configured ]] || [[ "${state}" == created ]] || [[ "${state}" == exited ]] || [[ "${state}" == stopped ]]; then
         container_start
     elif [[ "${state}" != running ]]; then
         echo "Container '${TOOLBOX_NAME}' in unknown state: '$state'"


### PR DESCRIPTION
The `toolbox` command reports that the container is in an unknown
state `created`. Addressed the issue by adding the state 'created'
in the conditional statements of the toolbox state.

Resolves JIRA: https://issues.redhat.com/browse/OCPBUGSM-45019
Bugzilla : https://bugzilla.redhat.com/show_bug.cgi?id=2093040