### PR TITLE
Bug 1915537:  Workaround "podman exec" using the wrong mount namespace

### DIFF
--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -137,7 +137,7 @@ container_create() {
         --volume /var/log:/var/log \
         --volume /etc/machine-id:/etc/machine-id \
         --volume /etc/localtime:/etc/localtime \
-        --volume /:/host \        
+        --volume /:/host \
         "${TOOLBOX_IMAGE}" 2>&1; then
         echo "$0: failed to create container '${TOOLBOX_NAME}'"
         exit 1

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -168,39 +168,15 @@ container_create_runlabel() {
 }
 
 container_exec() {
-    local arg=$@
-    echo "$arg"
-    echo "$#"
     if [[ "$#" -eq 0 ]]; then
-        echo "exec1"
         cmd=$(sudo podman image inspect "${TOOLBOX_IMAGE}" | jq -re ".[].Config.Cmd[0]") || cmd="/bin/sh"
         sudo podman attach \
             "${TOOLBOX_NAME}"
     else
-        echo "exec2"
         sudo podman run \
-                 --hostname toolbox \
-                 --name "$TOOLBOX_NAME" \
-                 --privileged \
-                 --net=host \
-                 --pid=host \
-                 --ipc=host \
-                 --tty \
-                 --interactive \
-                 --env HOST=/host \
-                 --env NAME="$TOOLBOX_NAME" \
-                 --env IMAGE="$IMAGE" \
-                 --env LANG="${LANG}" \
-                 --env TERM="${TERM}" \
                  --rm
-                 --security-opt label=disable \
-                 --volume /run:/run \
-                 --volume /var/log:/var/log \
-                 --volume /etc/machine-id:/etc/machine-id \
-                 --volume /etc/localtime:/etc/localtime \
-                 --volume /:/host \
                  "$TOOLBOX_IMAGE" \
-                 "$arg"
+                 "$@"
     fi
 }
 

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -127,17 +127,17 @@ container_create() {
         --ipc=host \
         --tty \
         --interactive \
-        -e HOST=/host \
-        -e NAME="${TOOLBOX_NAME}" \
-        -e IMAGE="${IMAGE}" \
+        --env HOST=/host \
+        --env NAME="${TOOLBOX_NAME}" \
+        --env IMAGE="${IMAGE}" \
+        --env LANG="${LANG}" \
+        --env TERM="${TERM}" \
         --security-opt label=disable \
         --volume /run:/run \
         --volume /var/log:/var/log \
         --volume /etc/machine-id:/etc/machine-id \
         --volume /etc/localtime:/etc/localtime \
         --volume /:/host \        
-        --env LANG="${LANG}" \
-        --env TERM="${TERM}" \
         "${TOOLBOX_IMAGE}" 2>&1; then
         echo "$0: failed to create container '${TOOLBOX_NAME}'"
         exit 1

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -180,17 +180,6 @@ container_exec() {
     fi
 }
 
-#container_exec() {
-#    if [[ "$#" -eq 0 ]]; then
-#        cmd=$(sudo podman image inspect "${TOOLBOX_IMAGE}" | jq -re ".[].Config.Cmd[0]") || cmd="/bin/sh"
-#        sudo podman attach \
-#            "${TOOLBOX_NAME}"
-#    else
-#        sudo podman attach \
-#            "${TOOLBOX_NAME}" 
-#    fi
-#}
-
 show_help() {
     echo "USAGE: toolbox [-h/--help] [command]
 toolbox is a small script that launches a container to let you bring in your favorite debugging or admin tools.

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -135,7 +135,9 @@ container_create() {
         --volume /var/log:/var/log \
         --volume /etc/machine-id:/etc/machine-id \
         --volume /etc/localtime:/etc/localtime \
-        --volume /:/host \
+        --volume /:/host \        
+        --env LANG="${LANG}" \
+        --env TERM="${TERM}" \
         "${TOOLBOX_IMAGE}" 2>&1; then
         echo "$0: failed to create container '${TOOLBOX_NAME}'"
         exit 1

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -130,8 +130,6 @@ container_create() {
         --env HOST=/host \
         --env NAME="${TOOLBOX_NAME}" \
         --env IMAGE="${IMAGE}" \
-        --env LANG="${LANG}" \
-        --env TERM="${TERM}" \
         --security-opt label=disable \
         --volume /run:/run \
         --volume /var/log:/var/log \

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -169,7 +169,7 @@ container_exec() {
     if [[ "$#" -eq 0 ]]; then
         cmd=$(sudo podman image inspect "${TOOLBOX_IMAGE}" | jq -re ".[].Config.Cmd[0]") || cmd="/bin/sh"
         sudo podman attach \
-            "${TOOLBOX_NAME}" \
+            "${TOOLBOX_NAME}"
     else
         sudo podman attach \
             "${TOOLBOX_NAME}" 

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -168,15 +168,52 @@ container_create_runlabel() {
 }
 
 container_exec() {
+    local arg=$@
+    echo "$arg"
+    echo "$#"
     if [[ "$#" -eq 0 ]]; then
+        echo "exec1"
         cmd=$(sudo podman image inspect "${TOOLBOX_IMAGE}" | jq -re ".[].Config.Cmd[0]") || cmd="/bin/sh"
         sudo podman attach \
             "${TOOLBOX_NAME}"
     else
-        sudo podman attach \
-            "${TOOLBOX_NAME}" 
+        echo "exec2"
+        sudo podman run \
+                 --hostname toolbox \
+                 --name "$TOOLBOX_NAME" \
+                 --privileged \
+                 --net=host \
+                 --pid=host \
+                 --ipc=host \
+                 --tty \
+                 --interactive \
+                 --env HOST=/host \
+                 --env NAME="$TOOLBOX_NAME" \
+                 --env IMAGE="$IMAGE" \
+                 --env LANG="${LANG}" \
+                 --env TERM="${TERM}" \
+                 --rm
+                 --security-opt label=disable \
+                 --volume /run:/run \
+                 --volume /var/log:/var/log \
+                 --volume /etc/machine-id:/etc/machine-id \
+                 --volume /etc/localtime:/etc/localtime \
+                 --volume /:/host \
+                 "$TOOLBOX_IMAGE" \
+                 "$arg"
     fi
 }
+
+#container_exec() {
+#    if [[ "$#" -eq 0 ]]; then
+#        cmd=$(sudo podman image inspect "${TOOLBOX_IMAGE}" | jq -re ".[].Config.Cmd[0]") || cmd="/bin/sh"
+#        sudo podman attach \
+#            "${TOOLBOX_NAME}"
+#    else
+#        sudo podman attach \
+#            "${TOOLBOX_NAME}" 
+#    fi
+#}
 
 show_help() {
     echo "USAGE: toolbox [-h/--help] [command]

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -174,6 +174,10 @@ container_exec() {
             "${TOOLBOX_NAME}"
     else
         sudo podman run \
+                 --env LANG="${LANG}" \
+                 --env TERM="${TERM}" \
+                 --tty \
+                 --interactive \
                  --rm
                  "$TOOLBOX_IMAGE" \
                  "$@"

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -168,21 +168,11 @@ container_create_runlabel() {
 container_exec() {
     if [[ "$#" -eq 0 ]]; then
         cmd=$(sudo podman image inspect "${TOOLBOX_IMAGE}" | jq -re ".[].Config.Cmd[0]") || cmd="/bin/sh"
-        sudo podman exec \
-            --env LANG="${LANG}" \
-            --env TERM="${TERM}" \
-            --tty \
-            --interactive \
+        sudo podman attach \
             "${TOOLBOX_NAME}" \
-            "${cmd}"
     else
-        sudo podman exec \
-            --env LANG="${LANG}" \
-            --env TERM="${TERM}" \
-            --tty \
-            --interactive \
-            "${TOOLBOX_NAME}" \
-            "$@"
+        sudo podman attach \
+            "${TOOLBOX_NAME}" 
     fi
 }
 

--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -178,7 +178,7 @@ container_exec() {
                  --env TERM="${TERM}" \
                  --tty \
                  --interactive \
-                 --rm
+                 --rm \
                  "$TOOLBOX_IMAGE" \
                  "$@"
     fi


### PR DESCRIPTION
On a second try to run sosreport from another debug pod raised anerror: "bash: sosreport: command not found"
By implementing "podman attach", the error could be cleared

Resolves JIRA: https://issues.redhat.com/browse/OCPBUGSM-23156
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1915537#c8