### PR TITLE
rhcos-toolbox(skopeo): Pass env to sudo when required

### DIFF
--- a/rhcos-toolbox
+++ b/rhcos-toolbox
@@ -98,7 +98,7 @@ image_fresh() {
     errecho "Checking if there is a newer version of ${TOOLBOX_IMAGE} available..."
     local_date=$(sudo podman image inspect "${TOOLBOX_IMAGE}" --format '{{.Created}}')
 
-    if ! remote_date=$(sudo skopeo inspect --authfile "${AUTHFILE}" docker://"${TOOLBOX_IMAGE}" --format '{{.Created}}'); then
+    if ! remote_date=$(sudo --preserve-env skopeo inspect --authfile "${AUTHFILE}" docker://"${TOOLBOX_IMAGE}" --format '{{.Created}}'); then
         errecho "Error inspecting ${TOOLBOX_IMAGE} via skopeo"
         return
     fi


### PR DESCRIPTION
Allow HTTP_PROXY and HTTPS_PROXY to pass through to skopeo.

Closes: #83 

Signed-off-by: Kenneth D'souza <kennethdsouza94@gmail.com>